### PR TITLE
Updated link to Docker Volume Reference

### DIFF
--- a/content/opensource/installation/index.md
+++ b/content/opensource/installation/index.md
@@ -162,7 +162,7 @@ http://localhost:82
 
 ### Volumes
 
-Instead of just running the Kerberos container, you can also persist your configuration by assigning volumes. An example of mounting volumes looks like this; an overview of [the different volumes can be found here](https://github.com/kerberos-io/docker/blob/master/Dockerfile#L171-L177).
+Instead of just running the Kerberos container, you can also persist your configuration by assigning volumes. An example of mounting volumes looks like this; an overview of [the different volumes can be found here](https://github.com/kerberos-io/kerberos-docker/blob/master/Dockerfile#L189-L194).
 
 - preload configuration,
 - or centralise the images/videos on your working station.


### PR DESCRIPTION
Seems like a moving target but I noticed this was off by a few lines while trying out Kerberos.io. Seems like the repo has been renamed since then as well.